### PR TITLE
Modify TFLAG attrs to be consistent with IOAPI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+2025-04-28 v0.4.2:
+* Fixed TFLAG attrs to be consistent with IOAPI output.
+
 2024-11-19 v0.4.1:
 * Dramatically improved documentation.
 * Fixed CMAQ date issue when just one time is available.

--- a/cmaqsatproc/__init__.py
+++ b/cmaqsatproc/__init__.py
@@ -70,7 +70,7 @@ from . import readers
 from . import cmaq
 from . import drivers
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 reader_dict = readers.reader_dict
 open_ioapi = cmaq.open_ioapi

--- a/cmaqsatproc/cmaq.py
+++ b/cmaqsatproc/cmaq.py
@@ -418,8 +418,8 @@ class CmaqSatProcAccessor:
             tflag = xr.DataArray(
                 tflag, dims=('TSTEP', 'VAR', 'DATE-TIME',),
                 attrs=dict(
-                    units='<YYYYJJJ,HHMMSS>', long_name='TFLAG'.ljust(16),
-                    var_desc='TFLAG'.ljust(80),
+                    units='<YYYYDDD,HHMMSS>', long_name='TFLAG'.ljust(16),
+                    var_desc='Timestep-valid flags:  (1) YYYYDDD or (2) HHMMSS'.ljust(80),
                 )
             )
             if outf.sizes['TSTEP'] > 1:


### PR DESCRIPTION
Modify the TFLAG attributes to be consistent with the IOAPI output to prevent errors when CMAQ reads time information.